### PR TITLE
remove incorrect syntax signifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Basically, PICAchooser loads the results of a MELODIC ICA run and lets you step 
 
 ## Usage
 
-``` bash
+```
 usage: PICAchooser runmode [options]
 PICAchooser: error: the following arguments are required: runmode
 usage: PICAchooser runmode [options]


### PR DESCRIPTION
By having this tagged as 'bash', github highlights words like 'in' and 'help' and 'for', which is not helpful in a help message.